### PR TITLE
Integrate preprocessing pipeline

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,11 +18,11 @@ import { DatabaseManager } from './database/databaseManager';
 import { SENSOR_IDS } from './config/config';
 
 // Initialize components
-const sensorManager = new SensorManager(SENSOR_IDS);
-const dataPreprocessor = new DataPreprocessor();
 const ontologyPopulator = new OntologyPopulator();
-const reasoner = new ProbabilisticReasoner();
 const dbManager = new DatabaseManager();
+const dataPreprocessor = new DataPreprocessor(ontologyPopulator, dbManager);
+const sensorManager = new SensorManager(SENSOR_IDS, dataPreprocessor);
+const reasoner = new ProbabilisticReasoner();
 
 async function main() {
   await dbManager.initialize();
@@ -41,12 +41,6 @@ async function main() {
         // Infer high-level activities
         const highLevelProbabilities = reasoner.inferHighLevelActivity(processedData.probabilities);
         console.log(`High-Level Probabilities: ${JSON.stringify(highLevelProbabilities)}`);
-
-        // Populate ontology
-        ontologyPopulator.addInstance(processedData);
-
-        // Insert into database
-        dbManager.insertInstance(processedData);
 
         // TODO: Update UI or take other actions
       }

--- a/src/preprocessing/dataPreprocessing.ts
+++ b/src/preprocessing/dataPreprocessing.ts
@@ -3,6 +3,8 @@
 import { SensorData } from '../sensors/sensorCollection';
 import { extractFeaturesFromData } from './featureExtraction';
 import { classifyLowLevelActivity } from '../classification/classifier';
+import { OntologyPopulator } from '../ontology/ontologyPopulation';
+import { DatabaseManager } from '../database/databaseManager';
 
 interface ProcessedData {
   timestamp: number;
@@ -13,10 +15,14 @@ interface ProcessedData {
 class DataPreprocessor {
   rawDataQueue: SensorData[];
   processedDataQueue: ProcessedData[];
+  ontologyPopulator: OntologyPopulator;
+  dbManager: DatabaseManager;
 
-  constructor() {
+  constructor(ontologyPopulator: OntologyPopulator, dbManager: DatabaseManager) {
     this.rawDataQueue = [];
     this.processedDataQueue = [];
+    this.ontologyPopulator = ontologyPopulator;
+    this.dbManager = dbManager;
   }
 
   enqueueRawData(dataPoint: SensorData) {
@@ -36,8 +42,9 @@ class DataPreprocessor {
           probabilities,
         };
         this.processedDataQueue.push(processedData);
-        // TODO: Send processedData to ontology population module
-        console.log(`Processed data: ${JSON.stringify(processedData)}`);
+        // Forward processed data to ontology and database services
+        this.ontologyPopulator.addInstance(processedData);
+        void this.dbManager.insertInstance(processedData);
       }
     }
   }

--- a/src/sensors/sensorCollection.ts
+++ b/src/sensors/sensorCollection.ts
@@ -1,6 +1,7 @@
 // src/sensors/sensorCollection.ts
 
 import { SENSOR_IDS, SAMPLING_RATE } from '../config/config';
+import { DataPreprocessor } from '../preprocessing/dataPreprocessing';
 
 interface SensorData {
   sensorId: number;
@@ -30,10 +31,12 @@ class Sensor {
 class SensorManager {
   sensors: Sensor[];
   running: boolean;
+  dataPreprocessor: DataPreprocessor;
 
-  constructor(sensorIds: number[]) {
+  constructor(sensorIds: number[], dataPreprocessor: DataPreprocessor) {
     this.sensors = sensorIds.map((id) => new Sensor(id));
     this.running = false;
+    this.dataPreprocessor = dataPreprocessor;
   }
 
   startCollection() {
@@ -47,11 +50,11 @@ class SensorManager {
 
   async collectData() {
     while (this.running) {
-      for (const sensor of this.sensors) {
-        const dataPoint = sensor.readData();
-        // TODO: Send dataPoint to the data preprocessing module
-        console.log(`Collected data: ${JSON.stringify(dataPoint)}`);
-      }
+        for (const sensor of this.sensors) {
+          const dataPoint = sensor.readData();
+          // Send dataPoint to the data preprocessing module
+          this.dataPreprocessor.enqueueRawData(dataPoint);
+        }
       await this.sleep(SAMPLING_RATE * 1000);
     }
   }


### PR DESCRIPTION
## Summary
- Route sensor data to the preprocessing queue instead of logging
- Forward processed data to ontology and database services
- Update main pipeline wiring for new dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Cannot find module '@vitejs/plugin-react')*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68ba8175cdcc8331bb78329a8d7734bc